### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,18 @@ FROM python:3.9
 WORKDIR /app/backend
 
 COPY requirements.txt /app/backend
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y gcc default-libmysqlclient-dev pkg-config \
-    && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y gcc default-libmysqlclient-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install app dependencies
 RUN pip install mysqlclient
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /app/backend
 
 EXPOSE 8000
-#RUN python manage.py migrate
-#RUN python manage.py makemigrations
+
+# Run Django development server
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
The original Dockerfile successfully built the image, but the container exited immediately after starting because it lacked a CMD instruction. By default, the container was executing python3 with no arguments, which opens an interactive shell and exits instantly in a non-interactive container.

What Was Changed
Added the following line to the end of the Dockerfile:
CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
Impact
1.Ensures the container starts and keeps running by launching the Django development server.

2.Makes the Django app accessible on port 8000 from outside the container.

3.Helps developers test the application inside a Docker environment without manual commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Dockerfile readability by consolidating commands.
  - Updated container startup to automatically run the Django development server on port 8000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->