### PR TITLE
Add CMD instruction to run Django server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app/backend
 
 EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 #RUN python manage.py migrate
 #RUN python manage.py makemigrations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Containers now auto-start the web app on launch, simplifying local runs. The app is accessible on port 8000 by default for browser access.

* Chores
  * Updated container configuration to include a default startup command aligned with the exposed port, reducing manual steps during development and testing and improving consistency across environments for faster onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->