### PR TITLE
Updated Jenkinsfile in Image Build stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+data/mysql

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline{
         }
         stage("Code Build"){
             steps{
-            dockerbuild("notes-app","latest")
+            dockerbuild("django_app","latest")
             }
         }
         stage("Push to DockerHub"){

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   django_app:
     build:
       context: .
-    image: django_app
+    image: jsrku/django_app
     container_name: "django_cont"
     ports:
       - "8000:8000"


### PR DESCRIPTION
The name of build in Jenkinsfile and docker-compose.yml was not same due to which container was not able to run and builds get failed each time when build was initiated from Jenkins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the Docker image source used by the build pipeline and local service to a new image identifier; runtime service settings were left unchanged.
  * Excluded development data from the Docker build context to prevent it from being included in image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->