### PR TITLE
Optimize Dockerfile by removing apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app/backend
 
 COPY requirements.txt /app/backend
 RUN apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y gcc default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Removed apt-get upgrade from Dockerfile to streamline build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automatic operating system package upgrade step from the container image build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->